### PR TITLE
fix linker error in bef_executor when compiling with -c dbg

### DIFF
--- a/backends/gpu/lib/stream/cudart_wrapper.cc
+++ b/backends/gpu/lib/stream/cudart_wrapper.cc
@@ -145,11 +145,6 @@ llvm::Error CudaFuncSetAttribute(CurrentContext current, const void* function,
   return TO_ERROR(cudaFuncSetAttribute(function, attribute, value));
 }
 
-llvm::Error CudaStreamSynchronize(CurrentContext current, CUstream stream) {
-  CheckCudaContext(current);
-  return TO_ERROR(cudaStreamSynchronize(stream));
-}
-
 }  // namespace stream
 }  // namespace gpu
 }  // namespace tfrt

--- a/backends/gpu/lib/stream/cudart_wrapper.cc
+++ b/backends/gpu/lib/stream/cudart_wrapper.cc
@@ -145,6 +145,11 @@ llvm::Error CudaFuncSetAttribute(CurrentContext current, const void* function,
   return TO_ERROR(cudaFuncSetAttribute(function, attribute, value));
 }
 
+llvm::Error CudaStreamSynchronize(CurrentContext current, CUstream stream) {
+  CheckCudaContext(current);
+  return TO_ERROR(cudaStreamSynchronize(stream));
+}
+
 }  // namespace stream
 }  // namespace gpu
 }  // namespace tfrt

--- a/backends/gpu/tools/stub_codegen/cudart.json
+++ b/backends/gpu/tools/stub_codegen/cudart.json
@@ -21,6 +21,7 @@
       "cudaFuncSetSharedMemConfig",
       "cudaFuncGetAttributes",
       "cudaFuncSetAttribute",
+      "cudaStreamSynchronize",
       "cudaOccupancyMaxActiveBlocksPerMultiprocessorWithFlags"
    ]
 }


### PR DESCRIPTION
util_device.cuh, part of cub, has a call to cudaStreamSynchronize.
In debug mode, the calling function is not removed, resulting in
a linker error.
this PR Adds cudaStreamSynchronize to cudart wrapper

Thanks for your contribution! Unfortunately, tensorflow/runtime is currently not
accepting contributions. Please see the
[Contribution Guidelines](../blob/master/README.md#contribution-guidelines) for
more information.
