### PR TITLE
Fix Windows build breaks

### DIFF
--- a/documents/explicit_dependency.md
+++ b/documents/explicit_dependency.md
@@ -37,7 +37,7 @@ of `Chain`. `Chain` is an empty struct defined in
 as follows:
 
 ```c++
-struct Chain {};
+class Chain {};
 ```
 
 The sole purpose of `Chain` is to add dependencies between kernels that

--- a/include/tfrt/host_context/chain.h
+++ b/include/tfrt/host_context/chain.h
@@ -31,7 +31,7 @@
 
 namespace tfrt {
 
-struct Chain {};
+class Chain {};
 
 class ReadyChain {
  public:

--- a/include/tfrt/host_context/diagnostic.h
+++ b/include/tfrt/host_context/diagnostic.h
@@ -33,7 +33,8 @@ namespace tfrt {
 class ExecutionContext;
 
 // This is a simple representation of a decoded diagnostic.
-struct DecodedDiagnostic {
+class DecodedDiagnostic {
+ public:
   // TODO(b/169618466): carry error code in llvm::Error.
   explicit DecodedDiagnostic(const Error& error);
   explicit DecodedDiagnostic(string_view message) : message(message) {}

--- a/include/tfrt/tensor/tensor_metadata.h
+++ b/include/tfrt/tensor/tensor_metadata.h
@@ -26,7 +26,8 @@ namespace tfrt {
 
 // The metadata of a rectangular tensor that can be computed by a metadata
 // function.
-struct TensorMetadata {
+class TensorMetadata {
+ public:
   TensorMetadata() : shape({}), dtype() {}
 
   TensorMetadata(DType dtype, const TensorShape& shape)

--- a/third_party/llvm/llvm.bzl
+++ b/third_party/llvm/llvm.bzl
@@ -294,11 +294,6 @@ win32_cmake_vars = {
 
     # LLVM features
     "LTDL_SHLIB_EXT": ".dll",
-
-    # ThreadPoolExecutor global destructor and thread handshaking do not work
-    # on this platform when used as a DLL.
-    # See: https://bugs.llvm.org/show_bug.cgi?id=44211
-    "LLVM_ENABLE_THREADS": 0,
 }
 
 # Select a set of CMake variables based on the platform.


### PR DESCRIPTION
This PR fixes #61 and #67

#61 - Don't disable LLVM_ENABLE_THREADS. The root LLVM issue appears to be fixed (https://bugs.llvm.org/show_bug.cgi?id=44211) and recent MLIR changes introduced a dependency on llvm::ThreadPool

#67 - MSVC requires consistent struct/class usage across declarations and definitions. This is technically a MSVC bug, but with a long history and unlikely to get fixed (the struct/class result in different name name mangling and will result in painful to debug linking issues)