### PR TITLE
Remove uses of `incompatible_use_toolchain_transition` now that it is…

### DIFF
--- a/third_party/rules_cuda/private/build.bzl
+++ b/third_party/rules_cuda/private/build.bzl
@@ -40,7 +40,6 @@ detect_cuda_toolchain = rule(
         ),
     },
     toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],
-    incompatible_use_toolchain_transition = True,
     fragments = ["cpp"],
 )
 


### PR DESCRIPTION
… enabled by

default in Bazel 5.0.

This is a step towards removing it entirely.

Part of https://github.com/bazelbuild/bazel/issues/14127.
