### PR TITLE
Removed platform dependent implementation in BlasTrsmBatch kernel

### DIFF
--- a/backends/gpu/include/tfrt/gpu/wrapper/blas_wrapper.h
+++ b/backends/gpu/include/tfrt/gpu/wrapper/blas_wrapper.h
@@ -94,6 +94,23 @@ llvm::Error BlasGemmStridedBatchedEx(
     Pointer<const void> beta, Pointer<void> C, BlasDataType typeC, int heightC,
     int64_t strideC, int batchCount, BlasComputeType computeType,
     BlasGemmAlgo algo);
+llvm::Error BlasTrsmBatched(
+                            CurrentContext current, 
+                            BlasHandle handle, 
+                            Pointer<void> pointer_array,
+                            BlasSideMode side_mode,
+                            BlasFillMode fill_mode,
+                            BlasOperation trans, 
+                            BlasDiagType diag_type,
+                            BlasDataType data_type,
+                            int m, 
+                            int n, 
+                            Pointer<void> alpha_ptr,
+                            Pointer<void> A, 
+                            int heightA,
+                            Pointer<void> B, 
+                            int heightB, 
+                            int batchCount);
 
 }  // namespace wrapper
 }  // namespace gpu

--- a/backends/gpu/include/tfrt/gpu/wrapper/blas_wrapper.h
+++ b/backends/gpu/include/tfrt/gpu/wrapper/blas_wrapper.h
@@ -97,7 +97,7 @@ llvm::Error BlasGemmStridedBatchedEx(
 llvm::Error BlasTrsmBatched(
                             CurrentContext current, 
                             BlasHandle handle, 
-                            Pointer<void> pointer_array,
+                            Pointer<char*> pointer_array,
                             BlasSideMode side_mode,
                             BlasFillMode fill_mode,
                             BlasOperation trans, 

--- a/backends/gpu/include/tfrt/gpu/wrapper/wrapper.h
+++ b/backends/gpu/include/tfrt/gpu/wrapper/wrapper.h
@@ -91,6 +91,7 @@
 #include <functional>
 #include <memory>
 #include <type_traits>
+#include <complex>
 
 #include "llvm/ADT/PointerUnion.h"
 #include "llvm/Support/Error.h"

--- a/backends/gpu/lib/kernels/blas_kernels.cc
+++ b/backends/gpu/lib/kernels/blas_kernels.cc
@@ -177,63 +177,29 @@ static Error BlasTrsmBatch(
     Attribute<int32_t> trans) {
   // TODO(hanbinyoon): Also support the ROCm function corresponding to
   // cublas<t>trsmBatched.
-  auto platform = handle->platform();
-  if (platform != wrapper::Platform::CUDA && platform != wrapper::Platform::ROCm)
-    return MakeStringError("Unsupported platform ", platform);
+  auto current = wrapper::CtxSetCurrent(handle.context()->get());
+  if (!current) return current.takeError();
 
-  rocblas_datatype data_type = wrapper::BlasDataType::FromOpaqueValue(*dataType);
-  auto alpha_ptr = GetScalePointer(alpha, static_cast<wrapper::BlasDataType>(data_type));
+  if (auto error = wrapper::BlasSetStream(handle.get(), stream.get()))
+    return error;
+
+  auto data_type = wrapper::BlasDataType::FromOpaqueValue(*dataType); 
+  auto alpha_ptr = GetScalePointer(alpha, data_type);
   if (!alpha_ptr) return alpha_ptr.takeError();
 
-  auto call = [&](auto dummy) {
-    auto current = wrapper::CtxSetCurrent(handle.context()->get());
-    if (!current) return current.takeError();
-
-    if (auto error = wrapper::BlasSetStream(handle.get(), stream.get()))
-      return error;
-
-    using T = decltype(dummy);
-    auto pointer_array =
-        handle.context()->AllocateHostPoolMemory<T*>(*current, 2 * batchCount);
+  auto pointer_array =
+        handle.context()->AllocateHostPoolMemory<char*>(*current, 2 * batchCount);
     if (!pointer_array) return pointer_array.takeError();
-    T** b_array = pointer_array->get().raw(platform);
-    const T** a_array = const_cast<const T**>(b_array + batchCount);
 
-    auto side_mode = wrapper::BlasSideMode::FromOpaqueValue(*sideMode);
-    ptrdiff_t a_batch_stride = (side_mode == rocblas_side_left) ? m * m : n * n;
-    ptrdiff_t b_batch_stride = m * n;
-    const T* a_ptr = static_cast<const T*>(A.pointer().raw(platform));
-    T* b_ptr = static_cast<T*>(B.pointer().raw(platform));
-    for (int32_t i = 0; i < batchCount; ++i) {
-      a_array[i] = a_ptr + i * a_batch_stride;
-      b_array[i] = b_ptr + i * b_batch_stride;
-    }
-
-    wrapper::Pointer<const T*> a_array_ptr(a_array, platform);
-    wrapper::Pointer<T*> b_array_ptr(b_array, platform);
-    auto cast_alpha_ptr = static_cast<wrapper::Pointer<const T>>(*alpha_ptr);
-
-    
-    return wrapper::RocblasTrsmBatched(
-         *current, handle.get(), side_mode,
-         wrapper::BlasFillMode::FromOpaqueValue(*fillMode),
-         wrapper::BlasOperation::FromOpaqueValue(*trans),
-         wrapper::BlasDiagType::FromOpaqueValue(*diagType), m, n, cast_alpha_ptr,
-         a_array_ptr, heightA, b_array_ptr, heightB, batchCount);
-  };
-
-  switch (data_type) {
-    case rocblas_datatype_f32_r:
-      return call(float{});
-    case rocblas_datatype_f64_r:
-      return call(double{});
-    case rocblas_datatype_f32_c:
-      return call(rocblas_float_complex{});
-    case rocblas_datatype_f64_c:
-      return call(rocblas_double_complex{});
-    default:
-      return MakeStringError("Unsupported data type ", data_type);
-  }
+  return wrapper::BlasTrsmBatched(
+       *current, handle.get(), 
+       pointer_array->get(),
+       wrapper::BlasSideMode::FromOpaqueValue(*sideMode),
+       wrapper::BlasFillMode::FromOpaqueValue(*fillMode),
+       wrapper::BlasOperation::FromOpaqueValue(*trans),
+       wrapper::BlasDiagType::FromOpaqueValue(*diagType), 
+       data_type, m, n, *alpha_ptr,
+       A.pointer(), heightA, B.pointer(), heightB, batchCount);
 }
 
 void RegisterGpuBlasKernels(KernelRegistry* kernel_reg) {

--- a/backends/gpu/lib/wrapper/cublas_enums.cc
+++ b/backends/gpu/lib/wrapper/cublas_enums.cc
@@ -396,6 +396,10 @@ mlir::TypeID GetCudaDataTypeId(cudaDataType data_type) {
       return mlir::TypeID::get<float>();
     case CUDA_R_64F:
       return mlir::TypeID::get<double>();
+    case CUDA_C_32F:
+      return mlir::TypeID::get<std::complex<float>>();;
+    case CUDA_C_64F:
+      return mlir::TypeID::get<std::complex<double>>();;
     default:
       return {};
   }

--- a/backends/gpu/lib/wrapper/rocblas_enums.cc
+++ b/backends/gpu/lib/wrapper/rocblas_enums.cc
@@ -228,6 +228,10 @@ mlir::TypeID GetRocblasDatatypeId(rocblas_datatype data_type) {
       return mlir::TypeID::get<float>();
     case rocblas_datatype_f64_r:
       return mlir::TypeID::get<double>();
+    case rocblas_datatype_f32_c:
+      return mlir::TypeID::get<std::complex<float>>();;
+    case rocblas_datatype_f64_c:
+      return mlir::TypeID::get<std::complex<double>>();;
     default:
       return {};
   }

--- a/backends/gpu/mlir_tests/rocm/BUILD
+++ b/backends/gpu/mlir_tests/rocm/BUILD
@@ -1,0 +1,30 @@
+load("@tf_runtime//:build_defs.bzl", "if_oss")
+load("@tf_runtime//tools:mlir_to_bef.bzl", "glob_tfrt_lit_tests")
+
+licenses(["notice"])
+
+glob_tfrt_lit_tests(
+    data = [":test_utilities"],
+    # copybara:uncomment driver = "@tf_runtime//backends/gpu/mlir_tests:run_lit.sh",
+    tags_override = dict({
+        file: ["requires-gpu-nvidia"]
+        for file in glob(["*.mlir"])
+    }.items() + {
+        # Note: NCCL in the sandbox produces the wrong result in OSS.
+        "ccl.mlir": ["requires-gpu-nvidia:2"] + if_oss(["no-sandbox"]),
+    }.items()),
+    tfrt_translate = "@tf_runtime//backends/gpu:tfrt_gpu_translate",
+)
+
+# Bundle together all of the test utilities that are used by tests.
+filegroup(
+    name = "test_utilities",
+    testonly = True,
+    srcs = [
+        "@llvm-project//llvm:FileCheck",
+        "@tf_runtime//backends/gpu:tfrt_gpu_executor",
+        "@tf_runtime//backends/gpu:tfrt_gpu_opt",
+        "@tf_runtime//backends/gpu:tfrt_gpu_translate",
+        "@tf_runtime//tools:bef_executor_lite",
+    ],
+)

--- a/backends/gpu/mlir_tests/rocm/blas.mlir
+++ b/backends/gpu/mlir_tests/rocm/blas.mlir
@@ -1,0 +1,193 @@
+// Copyright 2020 The TensorFlow Runtime Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// RUN: bef_executor_lite %s.bef | FileCheck %s
+
+// CHECK-LABEL: --- Running 'blas_axpy'
+func @blas_axpy() {
+  %ch1 = tfrt.new.chain
+  %ordinal = tfrt.constant.i32 0
+  %device = tfrt_gpu.device.get ROCm, %ordinal
+  %context = tfrt_gpu.context.create %device
+  %allocator = tfrt_gpu.allocator.create %context
+  %stream = tfrt_gpu.stream.create %context
+  %blas = tfrt_gpu.blas.create %context
+
+  %buffer_length = tfrt.constant.i32 4 // [2, 2] = 4 floats
+  %buffer_size_bytes = tfrt.constant.i64 16 // [2, 2] * 4 bytes floats = 16 bytes
+
+  %host_tensor = tfrt_dht.create_uninitialized_tensor.f32.2 [2 : i64, 2 : i64]
+  %host_buffer, %ch2 = tfrt_dht.get_buffer %host_tensor, %ch1
+
+  %ch3 = tfrt_dht.set_tensor_with_constant_values.f32 %host_tensor, %ch2 [1.0 : f32, 2.0 : f32, 3.0 : f32, 4.0 : f32]
+  %gpu_buffer_0 = tfrt_gpu.mem.allocate %allocator, %stream, %buffer_size_bytes, %ch3
+  %ch4 = tfrt_gpu.mem.copy %gpu_buffer_0, %host_buffer, %stream, %ch3 : !tfrt_gpu.buffer, !ht.host_buffer
+
+  %ch5 = tfrt_dht.set_tensor_with_constant_values.f32 %host_tensor, %ch4 [2.0 : f32, 3.0 : f32, 4.0 : f32, 5.0 : f32]
+  %gpu_buffer_1 = tfrt_gpu.mem.allocate %allocator, %stream, %buffer_size_bytes, %ch5
+  %ch6 = tfrt_gpu.mem.copy %gpu_buffer_1, %host_buffer, %stream, %ch5 : !tfrt_gpu.buffer, !ht.host_buffer
+
+  %stride = tfrt.constant.i32 1
+  %alpha = tfrt.constant.f32 1.0
+  %ch7 = tfrt_gpu.blas.axpy %blas, %stream, %buffer_length, %alpha, rocblas_datatype_f32_r, 
+         %gpu_buffer_0, rocblas_datatype_f32_r, %stride, %gpu_buffer_1, rocblas_datatype_f32_r, %stride,
+         rocblas_datatype_f32_r, %ch6
+
+  %ch8 = tfrt_gpu.mem.copy %host_buffer, %gpu_buffer_1, %stream, %ch7 : !ht.host_buffer, !tfrt_gpu.buffer
+  %ch9 = tfrt_gpu.stream.synchronize %stream, %ch8
+  // CHECK: DenseHostTensor dtype = f32, shape = [2, 2]
+  // CHECK-SAME: values = [3.000000e+00, 5.000000e+00, 7.000000e+00, 9.000000e+00]
+  %ch10 = tfrt_dht.print_tensor %host_tensor, %ch9
+
+  tfrt.return
+}
+
+// CHECK-LABEL: --- Running 'blas_gemm'
+func @blas_gemm() {
+  %ch1 = tfrt.new.chain
+  %ordinal = tfrt.constant.i32 0
+  %device = tfrt_gpu.device.get ROCm, %ordinal
+  %context = tfrt_gpu.context.create %device
+  %allocator = tfrt_gpu.allocator.create %context
+  %stream = tfrt_gpu.stream.create %context
+  %blas = tfrt_gpu.blas.create %context
+
+  %buffer_length = tfrt.constant.i32 4 // [2, 2] = 4 floats
+  %buffer_size_bytes = tfrt.constant.i64 16 // [2, 2] * 4 bytes floats = 16 bytes
+
+  %host_tensor = tfrt_dht.create_uninitialized_tensor.f32.2 [2 : i64, 2 : i64]
+  %host_buffer, %ch2 = tfrt_dht.get_buffer %host_tensor, %ch1
+
+  %ch3 = tfrt_dht.set_tensor_with_constant_values.f32 %host_tensor, %ch2 [1.0 : f32, 2.0 : f32, 3.0 : f32, 4.0 : f32]
+  %gpu_buffer_0 = tfrt_gpu.mem.allocate %allocator, %stream, %buffer_size_bytes, %ch3
+  %ch4 = tfrt_gpu.mem.copy %gpu_buffer_0, %host_buffer, %stream, %ch3 : !tfrt_gpu.buffer, !ht.host_buffer
+
+  %ch5 = tfrt_dht.set_tensor_with_constant_values.f32 %host_tensor, %ch4 [2.0 : f32, 3.0 : f32, 4.0 : f32, 5.0 : f32]
+  %gpu_buffer_1 = tfrt_gpu.mem.allocate %allocator, %stream, %buffer_size_bytes, %ch5
+  %ch6 = tfrt_gpu.mem.copy %gpu_buffer_1, %host_buffer, %stream, %ch5 : !tfrt_gpu.buffer, !ht.host_buffer
+
+  %ch7 = tfrt_dht.set_tensor_with_constant_values.f32 %host_tensor, %ch6 [0.0 : f32, 0.0 : f32, 0.0 : f32, 0.0 : f32]
+  %gpu_buffer_2 = tfrt_gpu.mem.allocate %allocator, %stream, %buffer_size_bytes, %ch7
+  %ch8 = tfrt_gpu.mem.copy %gpu_buffer_2, %host_buffer, %stream, %ch7 : !tfrt_gpu.buffer, !ht.host_buffer
+
+  %dim = tfrt.constant.i32 2
+  %alpha = tfrt.constant.f32 1.0
+  %beta = tfrt.constant.f32 1.0
+  %algo = tfrt_gpu.blas.gemm.algo rocblas_gemm_algo_standard
+  %ch9 = tfrt_gpu.blas.gemm %blas, %stream,
+    rocblas_operation_none, rocblas_operation_none, %dim, %dim, %dim,
+    %alpha, %gpu_buffer_0, rocblas_datatype_f32_r, %dim,
+    %gpu_buffer_1, rocblas_datatype_f32_r, %dim, %beta,
+    %gpu_buffer_2, rocblas_datatype_f32_r, %dim,
+    rocblas_datatype_f32_r, %algo, %ch8
+
+  %ch10 = tfrt_gpu.mem.copy %host_buffer, %gpu_buffer_2, %stream, %ch9 : !ht.host_buffer, !tfrt_gpu.buffer
+  %ch11 = tfrt_gpu.stream.synchronize %stream, %ch10
+  // CHECK: DenseHostTensor dtype = f32, shape = [2, 2]
+  // CHECK-SAME: values = [1.100000e+01, 1.600000e+01, 1.900000e+01, 2.800000e+01]
+  %ch12 = tfrt_dht.print_tensor %host_tensor, %ch11
+
+  tfrt.return
+}
+
+// CHECK-LABEL: --- Running 'blas_gemm_batched'
+func @blas_gemm_batched() {
+  %ch1 = tfrt.new.chain
+  %ordinal = tfrt.constant.i32 0
+  %device = tfrt_gpu.device.get ROCm, %ordinal
+  %context = tfrt_gpu.context.create %device
+  %allocator = tfrt_gpu.allocator.create %context
+  %stream = tfrt_gpu.stream.create %context
+  %blas = tfrt_gpu.blas.create %context
+
+  %buffer_length = tfrt.constant.i32 4 // [2, 2] = 4 floats
+  %buffer_size_bytes = tfrt.constant.i64 16 // [2, 2] * 4 bytes floats = 16 bytes
+
+  %host_tensor = tfrt_dht.create_uninitialized_tensor.f32.2 [2 : i64, 2 : i64]
+  %host_buffer, %ch2 = tfrt_dht.get_buffer %host_tensor, %ch1
+
+  %ch3 = tfrt_dht.set_tensor_with_constant_values.f32 %host_tensor, %ch2 [1.0 : f32, 2.0 : f32, 3.0 : f32, 4.0 : f32]
+  %gpu_buffer_0 = tfrt_gpu.mem.allocate %allocator, %stream, %buffer_size_bytes, %ch3
+  %ch4 = tfrt_gpu.mem.copy %gpu_buffer_0, %host_buffer, %stream, %ch3 : !tfrt_gpu.buffer, !ht.host_buffer
+
+  %ch5 = tfrt_dht.set_tensor_with_constant_values.f32 %host_tensor, %ch4 [2.0 : f32, 3.0 : f32, 4.0 : f32, 5.0 : f32]
+  %gpu_buffer_1 = tfrt_gpu.mem.allocate %allocator, %stream, %buffer_size_bytes, %ch5
+  %ch6 = tfrt_gpu.mem.copy %gpu_buffer_1, %host_buffer, %stream, %ch5 : !tfrt_gpu.buffer, !ht.host_buffer
+
+  %ch7 = tfrt_dht.set_tensor_with_constant_values.f32 %host_tensor, %ch6 [0.0 : f32, 0.0 : f32, 0.0 : f32, 0.0 : f32]
+  %gpu_buffer_2 = tfrt_gpu.mem.allocate %allocator, %stream, %buffer_size_bytes, %ch7
+  %ch8 = tfrt_gpu.mem.copy %gpu_buffer_2, %host_buffer, %stream, %ch7 : !tfrt_gpu.buffer, !ht.host_buffer
+
+  %dim = tfrt.constant.i32 2
+  %type = tfrt.constant.i32 0
+  %algo = tfrt_gpu.blas.gemm.algo rocblas_gemm_algo_standard
+  %alpha = tfrt.constant.f32 1.0
+  %beta = tfrt.constant.f32 1.0
+  %batch_count = tfrt.constant.i32 1
+  %stride = tfrt.constant.i64 1
+  %ch9 = tfrt_gpu.blas.gemm.batch %blas, %stream,
+    rocblas_operation_none, rocblas_operation_none, %dim, %dim, %dim,
+    %alpha, %gpu_buffer_0, rocblas_datatype_f32_r, %dim, %stride,
+    %gpu_buffer_1, rocblas_datatype_f32_r, %dim, %stride, %beta,
+    %gpu_buffer_2, rocblas_datatype_f32_r, %dim, %stride, %batch_count,
+    rocblas_datatype_f32_r, %algo, %ch8
+
+  %ch10 = tfrt_gpu.mem.copy %host_buffer, %gpu_buffer_2, %stream, %ch9 : !ht.host_buffer, !tfrt_gpu.buffer
+  %ch11 = tfrt_gpu.stream.synchronize %stream, %ch10
+  // CHECK: DenseHostTensor dtype = f32, shape = [2, 2]
+  // CHECK-SAME: values = [1.100000e+01, 1.600000e+01, 1.900000e+01, 2.800000e+01]
+  %ch12 = tfrt_dht.print_tensor %host_tensor, %ch11
+
+  tfrt.return
+}
+
+// CHECK-LABEL: --- Running 'blas_trsm_batched'
+func @blas_trsm_batched() {
+  %ch0 = tfrt.new.chain
+  %ordinal = tfrt.constant.i32 0
+  %device = tfrt_gpu.device.get ROCm, %ordinal
+  %context = tfrt_gpu.context.create %device
+  %allocator = tfrt_gpu.allocator.create %context
+  %stream = tfrt_gpu.stream.create %context
+  %blas = tfrt_gpu.blas.create %context
+
+  %buffer_size_bytes = tfrt.constant.i64 16 // [2, 2] * 4 bytes floats = 16 bytes
+
+  %host_tensor = tfrt_dht.create_uninitialized_tensor.f32.2 [2 : i64, 2 : i64]
+  %host_buffer, %ch1 = tfrt_dht.get_buffer %host_tensor, %ch0
+
+  %ch2 = tfrt_dht.set_tensor_with_constant_values.f32 %host_tensor, %ch1 [1.0 : f32, 2.0 : f32, 0.0 : f32, 1.0 : f32]
+  %gpu_buffer_0 = tfrt_gpu.mem.allocate %allocator, %stream, %buffer_size_bytes, %ch2
+  %ch3 = tfrt_gpu.mem.copy %gpu_buffer_0, %host_buffer, %stream, %ch2 : !tfrt_gpu.buffer, !ht.host_buffer
+
+  %ch4 = tfrt_dht.set_tensor_with_constant_values.f32 %host_tensor, %ch3 [1.0 : f32, 4.0 : f32, 0.0 : f32, 0.0 : f32]
+  %gpu_buffer_1 = tfrt_gpu.mem.allocate %allocator, %stream, %buffer_size_bytes, %ch4
+  %ch5 = tfrt_gpu.mem.copy %gpu_buffer_1, %host_buffer, %stream, %ch4 : !tfrt_gpu.buffer, !ht.host_buffer
+
+  %dim = tfrt.constant.i32 2
+  %alpha = tfrt.constant.f32 1.0
+  %batch_count = tfrt.constant.i32 1
+  %ch6 = tfrt_gpu.blas.trsm.batch %blas, %stream, rocblas_side_left,
+    rocblas_fill_lower, rocblas_operation_none, rocblas_diagonal_unit, %dim, %dim,
+    rocblas_datatype_f32_r, %alpha, %gpu_buffer_0, %dim, %gpu_buffer_1, %dim, %batch_count,
+    %ch5
+
+  %ch7 = tfrt_gpu.mem.copy %host_buffer, %gpu_buffer_1, %stream, %ch6 : !ht.host_buffer, !tfrt_gpu.buffer
+  %ch8 = tfrt_gpu.stream.synchronize %stream, %ch7
+  // CHECK: DenseHostTensor dtype = f32, shape = [2, 2]
+  // CHECK-SAME: values = [1.000000e+00, 2.000000e+00, 0.000000e+00, 0.000000e+00]
+  %ch9 = tfrt_dht.print_tensor %host_tensor, %ch8
+
+  tfrt.return
+}

--- a/backends/gpu/tools/stub_codegen/hip.json
+++ b/backends/gpu/tools/stub_codegen/hip.json
@@ -1,9 +1,9 @@
 {
-   "header":"/opt/rocm-4.2.0/include/hip/hip_runtime.h",
+   "header":"/opt/rocm-4.5.2/include/hip/hip_runtime.h",
    "extra_args":[
       "-D__HIP_PLATFORM_AMD__",
       "-I.",
-      "-I/opt/rocm-4.2.0/include/",
+      "-I/opt/rocm-4.5.2/include/",
       "-Ithird_party/llvm/llvm-project/clang/lib/Headers",
       "-Ibazel-genfiles",
       "-ferror-limit=0"
@@ -13,6 +13,7 @@
       "hipDeviceAttribute_t",
       "hipJitOption",
       "hipLimit_t",
+      "hipDataType",
       "hipMemoryType",
       "hipMemcpyKind",
       "hipFunction_attribute",

--- a/backends/gpu/tools/stub_codegen/hipfft.json
+++ b/backends/gpu/tools/stub_codegen/hipfft.json
@@ -1,8 +1,8 @@
 {
-   "header":"/opt/rocm-4.2.0/hipfft/include/hipfft.h",
+   "header":"/opt/rocm-4.5.2/hipfft/include/hipfft.h",
    "extra_args":[
       "-I.",
-      "-I/opt/rocm-4.2.0/include/"
+      "-I/opt/rocm-4.5.2/include/"
    ],
    "enums":[
       "hipfftLibraryPropertyType",

--- a/backends/gpu/tools/stub_codegen/miopen.json
+++ b/backends/gpu/tools/stub_codegen/miopen.json
@@ -1,8 +1,8 @@
 {
-   "header":"/opt/rocm-4.2.0/include/miopen/miopen.h",
+   "header":"/opt/rocm-4.5.2/include/miopen/miopen.h",
    "extra_args":[
       "-I.",
-      "-I/opt/rocm-4.2.0/include/"
+      "-I/opt/rocm-4.5.2/include/"
    ],
    "enums":[
       "miopenStatus_t",

--- a/backends/gpu/tools/stub_codegen/rocblas.json
+++ b/backends/gpu/tools/stub_codegen/rocblas.json
@@ -1,8 +1,8 @@
 {
-   "header":"/opt/rocm-4.2.0/include/rocblas.h",
+   "header":"/opt/rocm-4.5.2/include/rocblas.h",
    "extra_args":[
       "-I.",
-      "-I/opt/rocm-4.2.0/include/"
+      "-I/opt/rocm-4.5.2/include/"
    ],
    "enums":[
       "rocblas_operation",

--- a/backends/gpu/tools/stub_codegen/rocsolver.json
+++ b/backends/gpu/tools/stub_codegen/rocsolver.json
@@ -1,8 +1,8 @@
 {
-   "header":"/opt/rocm-4.2.0/include/rocsolver.h",
+   "header":"/opt/rocm-4.5.2/include/rocsolver.h",
    "extra_args":[
       "-I.",
-      "-I/opt/rocm-4.2.0/include/"
+      "-I/opt/rocm-4.5.2/include/"
    ],
    "functions":[
       "rocsolver_spotrf",

--- a/third_party/hip/hip_stub.cc.inc
+++ b/third_party/hip/hip_stub.cc.inc
@@ -12,16 +12,6 @@ hipError_t hipRuntimeGetVersion(int* runtimeVersion) {
       "hipRuntimeGetVersion", runtimeVersion);
 }
 
-hipError_t hipGetLastError(void) {
-  return DynamicCall<decltype(hipGetLastError), &hipGetLastError>(
-      "hipGetLastError");
-}
-
-hipError_t hipPeekAtLastError(void) {
-  return DynamicCall<decltype(hipPeekAtLastError), &hipPeekAtLastError>(
-      "hipPeekAtLastError");
-}
-
 hipError_t hipDeviceGet(hipDevice_t* device, int ordinal) {
   return DynamicCall<decltype(hipDeviceGet), &hipDeviceGet>("hipDeviceGet",
                                                             device, ordinal);
@@ -71,6 +61,16 @@ hipError_t hipGetDeviceProperties(hipDeviceProp_t* prop, int deviceId) {
 hipError_t hipDeviceGetLimit(size_t* pValue, enum hipLimit_t limit) {
   return DynamicCall<decltype(hipDeviceGetLimit), &hipDeviceGetLimit>(
       "hipDeviceGetLimit", pValue, limit);
+}
+
+hipError_t hipGetLastError(void) {
+  return DynamicCall<decltype(hipGetLastError), &hipGetLastError>(
+      "hipGetLastError");
+}
+
+hipError_t hipPeekAtLastError(void) {
+  return DynamicCall<decltype(hipPeekAtLastError), &hipPeekAtLastError>(
+      "hipPeekAtLastError");
 }
 
 hipError_t hipStreamCreateWithFlags(hipStream_t* stream, unsigned int flags) {
@@ -207,6 +207,12 @@ hipError_t hipMemcpy(void* dst, const void* src, size_t sizeBytes,
                      hipMemcpyKind kind) {
   return DynamicCall<decltype(hipMemcpy), &hipMemcpy>("hipMemcpy", dst, src,
                                                       sizeBytes, kind);
+}
+
+hipError_t hipModuleGetGlobal(hipDeviceptr_t* dptr, size_t* bytes,
+                              hipModule_t hmod, const char* name) {
+  return DynamicCall<decltype(hipModuleGetGlobal), &hipModuleGetGlobal>(
+      "hipModuleGetGlobal", dptr, bytes, hmod, name);
 }
 
 hipError_t hipMemcpyAsync(void* dst, const void* src, size_t sizeBytes,
@@ -375,13 +381,6 @@ hipError_t hipModuleGetFunction(hipFunction_t* function, hipModule_t module,
   return DynamicCall<decltype(hipModuleGetFunction), &hipModuleGetFunction>(
       "hipModuleGetFunction", function, module, kname);
 }
-
-hipError_t hipModuleGetGlobal(void** ptr, size_t* bytes, hipModule_t module,
-                              const char* kname) {
-  return DynamicCall<decltype(hipModuleGetGlobal), &hipModuleGetGlobal>(
-      "hipModuleGetGlobal", ptr, bytes, module, kname);
-}
-
 
 hipError_t hipFuncGetAttributes(struct hipFuncAttributes* attr,
                                 const void* func) {

--- a/third_party/hip/hip_stub.h.inc
+++ b/third_party/hip/hip_stub.h.inc
@@ -62,12 +62,22 @@ enum hipError_t {
   hipErrorPeerAccessAlreadyEnabled = 704,
   hipErrorPeerAccessNotEnabled = 705,
   hipErrorSetOnActiveProcess = 708,
+  hipErrorContextIsDestroyed = 709,
   hipErrorAssert = 710,
   hipErrorHostMemoryAlreadyRegistered = 712,
   hipErrorHostMemoryNotRegistered = 713,
   hipErrorLaunchFailure = 719,
   hipErrorCooperativeLaunchTooLarge = 720,
   hipErrorNotSupported = 801,
+  hipErrorStreamCaptureUnsupported = 900,
+  hipErrorStreamCaptureInvalidated = 901,
+  hipErrorStreamCaptureMerge = 902,
+  hipErrorStreamCaptureUnmatched = 903,
+  hipErrorStreamCaptureUnjoined = 904,
+  hipErrorStreamCaptureIsolation = 905,
+  hipErrorStreamCaptureImplicit = 906,
+  hipErrorCapturedEvent = 907,
+  hipErrorStreamCaptureWrongThread = 908,
   hipErrorUnknown = 999,
   hipErrorRuntimeMemory = 1052,
   hipErrorRuntimeOther = 1053,
@@ -153,6 +163,7 @@ enum hipFunction_attribute {
 };
 
 enum hipLimit_t {
+  hipLimitPrintfFifoSize = 0x01,
   hipLimitMallocHeapSize = 0x02,
 };
 
@@ -196,10 +207,6 @@ hipError_t hipDriverGetVersion(int* driverVersion);
 
 hipError_t hipRuntimeGetVersion(int* runtimeVersion);
 
-hipError_t hipGetLastError(void);
-
-hipError_t hipPeekAtLastError(void);
-
 hipError_t hipDeviceGet(hipDevice_t* device, int ordinal);
 
 hipError_t hipDeviceGetName(char* name, int len, hipDevice_t device);
@@ -220,6 +227,10 @@ hipError_t hipDeviceGetAttribute(int* pi, hipDeviceAttribute_t attr,
 hipError_t hipGetDeviceProperties(hipDeviceProp_t* prop, int deviceId);
 
 hipError_t hipDeviceGetLimit(size_t* pValue, enum hipLimit_t limit);
+
+hipError_t hipGetLastError(void);
+
+hipError_t hipPeekAtLastError(void);
 
 hipError_t hipStreamCreateWithFlags(hipStream_t* stream, unsigned int flags);
 
@@ -277,6 +288,9 @@ hipError_t hipHostFree(void* ptr);
 
 hipError_t hipMemcpy(void* dst, const void* src, size_t sizeBytes,
                      hipMemcpyKind kind);
+
+hipError_t hipModuleGetGlobal(hipDeviceptr_t* dptr, size_t* bytes,
+                              hipModule_t hmod, const char* name);
 
 hipError_t hipMemcpyAsync(void* dst, const void* src, size_t sizeBytes,
                           hipMemcpyKind kind, hipStream_t stream __dparm(0));
@@ -353,9 +367,6 @@ hipError_t hipModuleUnload(hipModule_t module);
 hipError_t hipModuleGetFunction(hipFunction_t* function, hipModule_t module,
                                 const char* kname);
 
-hipError_t hipModuleGetGlobal(void** ptr, size_t* bytes, hipModule_t module,
-                                const char* kname);
-
 hipError_t hipFuncGetAttributes(struct hipFuncAttributes* attr,
                                 const void* func);
 
@@ -385,3 +396,12 @@ hipError_t hipOccupancyMaxPotentialBlockSize(int* gridSize, int* blockSize,
                                              const void* f,
                                              size_t dynSharedMemPerBlk,
                                              int blockSizeLimit);
+
+enum hipDataType {
+  HIP_R_16F = 2,
+  HIP_R_32F = 0,
+  HIP_R_64F = 1,
+  HIP_C_16F = 6,
+  HIP_C_32F = 4,
+  HIP_C_64F = 5,
+};

--- a/third_party/hip/miopen_stub.h.inc
+++ b/third_party/hip/miopen_stub.h.inc
@@ -46,6 +46,7 @@ typedef enum {
   miopenInt8 = 3,
   miopenInt8x4 = 4,
   miopenBFloat16 = 5,
+  miopenDouble = 6,
 } miopenDataType_t;
 
 typedef enum {

--- a/third_party/hip/rocblas_stub.cc.inc
+++ b/third_party/hip/rocblas_stub.cc.inc
@@ -34,48 +34,6 @@ ROCBLAS_EXPORT rocblas_status rocblas_get_pointer_mode(
                                                 handle, pointer_mode);
 }
 
-ROCBLAS_EXPORT rocblas_status rocblas_gemm_ex(
-    rocblas_handle handle, rocblas_operation transA, rocblas_operation transB,
-    rocblas_int m, rocblas_int n, rocblas_int k, const void* alpha,
-    const void* a, rocblas_datatype a_type, rocblas_int lda, const void* b,
-    rocblas_datatype b_type, rocblas_int ldb, const void* beta, const void* c,
-    rocblas_datatype c_type, rocblas_int ldc, void* d, rocblas_datatype d_type,
-    rocblas_int ldd, rocblas_datatype compute_type, rocblas_gemm_algo algo,
-    int32_t solution_index, uint32_t flags) {
-  return DynamicCall<decltype(rocblas_gemm_ex), &rocblas_gemm_ex>(
-      "rocblas_gemm_ex", handle, transA, transB, m, n, k, alpha, a, a_type, lda,
-      b, b_type, ldb, beta, c, c_type, ldc, d, d_type, ldd, compute_type, algo,
-      solution_index, flags);
-}
-
-ROCBLAS_EXPORT rocblas_status rocblas_gemm_strided_batched_ex(
-    rocblas_handle handle, rocblas_operation transA, rocblas_operation transB,
-    rocblas_int m, rocblas_int n, rocblas_int k, const void* alpha,
-    const void* a, rocblas_datatype a_type, rocblas_int lda,
-    rocblas_stride stride_a, const void* b, rocblas_datatype b_type,
-    rocblas_int ldb, rocblas_stride stride_b, const void* beta, const void* c,
-    rocblas_datatype c_type, rocblas_int ldc, rocblas_stride stride_c, void* d,
-    rocblas_datatype d_type, rocblas_int ldd, rocblas_stride stride_d,
-    rocblas_int batch_count, rocblas_datatype compute_type,
-    rocblas_gemm_algo algo, int32_t solution_index, uint32_t flags) {
-  return DynamicCall<decltype(rocblas_gemm_strided_batched_ex),
-                     &rocblas_gemm_strided_batched_ex>(
-      "rocblas_gemm_strided_batched_ex", handle, transA, transB, m, n, k, alpha,
-      a, a_type, lda, stride_a, b, b_type, ldb, stride_b, beta, c, c_type, ldc,
-      stride_c, d, d_type, ldd, stride_d, batch_count, compute_type, algo,
-      solution_index, flags);
-}
-
-ROCBLAS_EXPORT rocblas_status rocblas_axpy_ex(
-    rocblas_handle handle, rocblas_int n, const void* alpha,
-    rocblas_datatype alpha_type, const void* x, rocblas_datatype x_type,
-    rocblas_int incx, void* y, rocblas_datatype y_type, rocblas_int incy,
-    rocblas_datatype execution_type) {
-  return DynamicCall<decltype(rocblas_axpy_ex), &rocblas_axpy_ex>(
-      "rocblas_axpy_ex", handle, n, alpha, alpha_type, x, x_type, incx, y,
-      y_type, incy, execution_type);
-}
-
 ROCBLAS_EXPORT rocblas_status rocblas_strsm_batched(
     rocblas_handle handle, rocblas_side side, rocblas_fill uplo,
     rocblas_operation transA, rocblas_diagonal diag, rocblas_int m,
@@ -119,4 +77,46 @@ ROCBLAS_EXPORT rocblas_status rocblas_ztrsm_batched(
   return DynamicCall<decltype(rocblas_ztrsm_batched), &rocblas_ztrsm_batched>(
       "rocblas_ztrsm_batched", handle, side, uplo, transA, diag, m, n, alpha, A,
       lda, B, ldb, batch_count);
+}
+
+ROCBLAS_EXPORT rocblas_status rocblas_gemm_ex(
+    rocblas_handle handle, rocblas_operation transA, rocblas_operation transB,
+    rocblas_int m, rocblas_int n, rocblas_int k, const void* alpha,
+    const void* a, rocblas_datatype a_type, rocblas_int lda, const void* b,
+    rocblas_datatype b_type, rocblas_int ldb, const void* beta, const void* c,
+    rocblas_datatype c_type, rocblas_int ldc, void* d, rocblas_datatype d_type,
+    rocblas_int ldd, rocblas_datatype compute_type, rocblas_gemm_algo algo,
+    int32_t solution_index, uint32_t flags) {
+  return DynamicCall<decltype(rocblas_gemm_ex), &rocblas_gemm_ex>(
+      "rocblas_gemm_ex", handle, transA, transB, m, n, k, alpha, a, a_type, lda,
+      b, b_type, ldb, beta, c, c_type, ldc, d, d_type, ldd, compute_type, algo,
+      solution_index, flags);
+}
+
+ROCBLAS_EXPORT rocblas_status rocblas_gemm_strided_batched_ex(
+    rocblas_handle handle, rocblas_operation transA, rocblas_operation transB,
+    rocblas_int m, rocblas_int n, rocblas_int k, const void* alpha,
+    const void* a, rocblas_datatype a_type, rocblas_int lda,
+    rocblas_stride stride_a, const void* b, rocblas_datatype b_type,
+    rocblas_int ldb, rocblas_stride stride_b, const void* beta, const void* c,
+    rocblas_datatype c_type, rocblas_int ldc, rocblas_stride stride_c, void* d,
+    rocblas_datatype d_type, rocblas_int ldd, rocblas_stride stride_d,
+    rocblas_int batch_count, rocblas_datatype compute_type,
+    rocblas_gemm_algo algo, int32_t solution_index, uint32_t flags) {
+  return DynamicCall<decltype(rocblas_gemm_strided_batched_ex),
+                     &rocblas_gemm_strided_batched_ex>(
+      "rocblas_gemm_strided_batched_ex", handle, transA, transB, m, n, k, alpha,
+      a, a_type, lda, stride_a, b, b_type, ldb, stride_b, beta, c, c_type, ldc,
+      stride_c, d, d_type, ldd, stride_d, batch_count, compute_type, algo,
+      solution_index, flags);
+}
+
+ROCBLAS_EXPORT rocblas_status rocblas_axpy_ex(
+    rocblas_handle handle, rocblas_int n, const void* alpha,
+    rocblas_datatype alpha_type, const void* x, rocblas_datatype x_type,
+    rocblas_int incx, void* y, rocblas_datatype y_type, rocblas_int incy,
+    rocblas_datatype execution_type) {
+  return DynamicCall<decltype(rocblas_axpy_ex), &rocblas_axpy_ex>(
+      "rocblas_axpy_ex", handle, n, alpha, alpha_type, x, x_type, incx, y,
+      y_type, incy, execution_type);
 }

--- a/third_party/hip/rocblas_stub.h.inc
+++ b/third_party/hip/rocblas_stub.h.inc
@@ -71,6 +71,7 @@ typedef enum rocblas_gemm_algo_ {
 typedef enum rocblas_gemm_flags_ {
   rocblas_gemm_flags_none = 0x0,
   rocblas_gemm_flags_pack_int8x4 = 0x1,
+  rocblas_gemm_flags_use_cu_efficiency = 0x2,
 } rocblas_gemm_flags;
 
 ROCBLAS_EXPORT rocblas_status rocblas_create_handle(rocblas_handle* handle);
@@ -88,32 +89,6 @@ ROCBLAS_EXPORT rocblas_status rocblas_set_pointer_mode(
 
 ROCBLAS_EXPORT rocblas_status rocblas_get_pointer_mode(
     rocblas_handle handle, rocblas_pointer_mode* pointer_mode);
-
-ROCBLAS_EXPORT rocblas_status rocblas_gemm_ex(
-    rocblas_handle handle, rocblas_operation transA, rocblas_operation transB,
-    rocblas_int m, rocblas_int n, rocblas_int k, const void* alpha,
-    const void* a, rocblas_datatype a_type, rocblas_int lda, const void* b,
-    rocblas_datatype b_type, rocblas_int ldb, const void* beta, const void* c,
-    rocblas_datatype c_type, rocblas_int ldc, void* d, rocblas_datatype d_type,
-    rocblas_int ldd, rocblas_datatype compute_type, rocblas_gemm_algo algo,
-    int32_t solution_index, uint32_t flags);
-
-ROCBLAS_EXPORT rocblas_status rocblas_gemm_strided_batched_ex(
-    rocblas_handle handle, rocblas_operation transA, rocblas_operation transB,
-    rocblas_int m, rocblas_int n, rocblas_int k, const void* alpha,
-    const void* a, rocblas_datatype a_type, rocblas_int lda,
-    rocblas_stride stride_a, const void* b, rocblas_datatype b_type,
-    rocblas_int ldb, rocblas_stride stride_b, const void* beta, const void* c,
-    rocblas_datatype c_type, rocblas_int ldc, rocblas_stride stride_c, void* d,
-    rocblas_datatype d_type, rocblas_int ldd, rocblas_stride stride_d,
-    rocblas_int batch_count, rocblas_datatype compute_type,
-    rocblas_gemm_algo algo, int32_t solution_index, uint32_t flags);
-
-ROCBLAS_EXPORT rocblas_status rocblas_axpy_ex(
-    rocblas_handle handle, rocblas_int n, const void* alpha,
-    rocblas_datatype alpha_type, const void* x, rocblas_datatype x_type,
-    rocblas_int incx, void* y, rocblas_datatype y_type, rocblas_int incy,
-    rocblas_datatype execution_type);
 
 ROCBLAS_EXPORT rocblas_status rocblas_strsm_batched(
     rocblas_handle handle, rocblas_side side, rocblas_fill uplo,
@@ -142,3 +117,29 @@ ROCBLAS_EXPORT rocblas_status rocblas_ztrsm_batched(
     const rocblas_double_complex* const A[], rocblas_int lda,
     rocblas_double_complex* const B[], rocblas_int ldb,
     rocblas_int batch_count);
+
+ROCBLAS_EXPORT rocblas_status rocblas_gemm_ex(
+    rocblas_handle handle, rocblas_operation transA, rocblas_operation transB,
+    rocblas_int m, rocblas_int n, rocblas_int k, const void* alpha,
+    const void* a, rocblas_datatype a_type, rocblas_int lda, const void* b,
+    rocblas_datatype b_type, rocblas_int ldb, const void* beta, const void* c,
+    rocblas_datatype c_type, rocblas_int ldc, void* d, rocblas_datatype d_type,
+    rocblas_int ldd, rocblas_datatype compute_type, rocblas_gemm_algo algo,
+    int32_t solution_index, uint32_t flags);
+
+ROCBLAS_EXPORT rocblas_status rocblas_gemm_strided_batched_ex(
+    rocblas_handle handle, rocblas_operation transA, rocblas_operation transB,
+    rocblas_int m, rocblas_int n, rocblas_int k, const void* alpha,
+    const void* a, rocblas_datatype a_type, rocblas_int lda,
+    rocblas_stride stride_a, const void* b, rocblas_datatype b_type,
+    rocblas_int ldb, rocblas_stride stride_b, const void* beta, const void* c,
+    rocblas_datatype c_type, rocblas_int ldc, rocblas_stride stride_c, void* d,
+    rocblas_datatype d_type, rocblas_int ldd, rocblas_stride stride_d,
+    rocblas_int batch_count, rocblas_datatype compute_type,
+    rocblas_gemm_algo algo, int32_t solution_index, uint32_t flags);
+
+ROCBLAS_EXPORT rocblas_status rocblas_axpy_ex(
+    rocblas_handle handle, rocblas_int n, const void* alpha,
+    rocblas_datatype alpha_type, const void* x, rocblas_datatype x_type,
+    rocblas_int incx, void* y, rocblas_datatype y_type, rocblas_int incy,
+    rocblas_datatype execution_type);


### PR DESCRIPTION
Thanks for your contribution! Unfortunately, tensorflow/runtime is currently not
accepting contributions. Please see the
[Contribution Guidelines](../blob/master/README.md#contribution-guidelines) for
more information.

Lower the platform dependent implementation of the kernel, BlasTrsmBatch, to the blas_wrapper.cc @chsigg @hanbinyoon @deven-amd 