### PR TITLE
Fix loading of rules_cuda_dependencies

### DIFF
--- a/third_party/rules_cuda/README.md
+++ b/third_party/rules_cuda/README.md
@@ -27,7 +27,7 @@ http_archive(
     strip_prefix = "runtime-b1c7cce21ba4661c17ac72421c6a0e2015e7bef3/third_party/rules_cuda",
     urls = ["https://github.com/tensorflow/runtime/archive/b1c7cce21ba4661c17ac72421c6a0e2015e7bef3.tar.gz"],
 )
-load("//cuda:dependencies.bzl", "rules_cuda_dependencies")
+load("@rules_cuda//cuda:dependencies.bzl", "rules_cuda_dependencies")
 rules_cuda_dependencies()
 load("@rules_cc//cc:repositories.bzl", "rules_cc_toolchains")
 rules_cc_toolchains()


### PR DESCRIPTION
Otherwise getting `ERROR: error loading package '': Label '//cuda:dependencies.bzl' is invalid because 'cuda' is not a package; perhaps you meant to put the colon here: '//:cuda/dependencies.bzl'?`

Thanks for your contribution! Unfortunately, tensorflow/runtime is currently not
accepting contributions. Please see the
[Contribution Guidelines](../blob/master/README.md#contribution-guidelines) for
more information.
