### PR TITLE
Add missing stdint header

### DIFF
--- a/include/tfrt/support/forward_decls.h
+++ b/include/tfrt/support/forward_decls.h
@@ -21,6 +21,7 @@
 #define TFRT_SUPPORT_FORWARD_DECLS_H_
 
 #include <cstddef>
+#include <cstdint>
 #include <memory>
 
 #include "llvm/Support/Casting.h"

--- a/include/tfrt/support/raw_coding.h
+++ b/include/tfrt/support/raw_coding.h
@@ -21,6 +21,7 @@
 #ifndef TFRT_SUPPORT_RAW_CODING_H_
 #define TFRT_SUPPORT_RAW_CODING_H_
 
+#include <cstdint>
 #include <cstring>
 
 #include "tfrt/support/forward_decls.h"


### PR DESCRIPTION
Fix building Tensorflow on RISC-V 64 with GCC13+.
